### PR TITLE
Fix method naming and call in TurnstileVerifier

### DIFF
--- a/app/services/turnstile_verifier.rb
+++ b/app/services/turnstile_verifier.rb
@@ -32,7 +32,7 @@ class TurnstileVerifier
 
   private
 
-  def attempt_verification?
+  def attempt_verification
     MAX_RETRIES.times do |attempt|
       return true if successful?(attempt)
 


### PR DESCRIPTION
Rename `attempt_verification?` to `attempt_verification` to accurately reflect its functionality and update the `verify` method to call the correct method, preventing potential errors during user login. Clarify intent and address misleading naming warnings.